### PR TITLE
Change default timeout in httpParty

### DIFF
--- a/lib/moip2/client.rb
+++ b/lib/moip2/client.rb
@@ -2,7 +2,9 @@ module Moip2
 
   class Client
     include HTTParty
-
+    # Setting a default timeout for all HTTP calls
+    default_timeout 180
+    
     attr_reader :env, :auth, :uri
 
     def initialize(env = :sandbox, auth = nil, opts = {})


### PR DESCRIPTION
I increased the time limit, because the api has suffered constant falls